### PR TITLE
feat(scripts): add freespace-ultra for Ultra.cc slots

### DIFF
--- a/scripts/freespace-ultra/README.md
+++ b/scripts/freespace-ultra/README.md
@@ -1,0 +1,76 @@
+# freespace-ultra
+
+This is a freespace script for Ultra.cc slots.
+
+```shell
+touch ~/freespace-ultra.sh && chmod +x ~/freespace-ultra.sh
+```
+
+Then open the file and paste the contents.
+
+## Description
+
+If the script sees that there is enough space available, it will return exit code 0 and autobrr will push the torrent to the download client.
+
+If free space falls below your limit, the script will return exit code 1 and autobrr will skip it.
+
+Set **Exec Args** to `{{.Size}}` and **Expected exit status** to `0`.
+
+## Why not just df
+
+On a slot your home directory sits on an array shared with every other user, and your plan is a filesystem user quota. `df` reports the array, not your quota, and qBittorrent's own "free space on disk" comes from the same place, so it is wrong in the same way.
+
+A slot with 250 GiB of quota left can sit on an array reporting 10 TiB free. A `df` check never fires, and the grabs keep coming until writes fail.
+
+So the script reads your quota, and uses the smaller of your quota headroom and the array, because either one can be what stops the write.
+
+Everything here is in GiB, matching your torrent client. The Ultra panel shows GB, so the same space reads as a larger number there. 9313 GiB of quota is 10000 GB on the panel.
+
+## Releases with no announced size
+
+Not every tracker puts a size on the announce line. autobrr only works the real size out *after* external filters have run:
+
+```go
+func (f *Filter) checkSizeFilter(r *Release) bool {
+	if r.Size == 0 {
+		r.AdditionalSizeCheckRequired = true
+		return true
+	}
+```
+
+So `{{.Size}}` arrives here as `0`, and a `max_size` on the filter does not change that. Reading `0` as "needs nothing" would let any release through, so the script assumes `ASSUME_GIB`.
+
+Set `ASSUME_GIB` to your filter's `max_size`. That is the largest release the filter can accept, so the guess is never too big or too small.
+
+## Configuration
+
+Edit the values at the top of the script:
+
+| Variable | Meaning |
+| --- | --- |
+| `BUFFER_GIB` | Headroom to keep free on top of the release. Default 50. |
+| `ASSUME_GIB` | Size assumed when the announce carries no size. Set to your filter's `max_size`. Default 50. |
+| `CHECK_PATH` | Any path on the filesystem you download to. Defaults to `$HOME`. |
+
+`BUFFER_GIB` and `ASSUME_GIB` can also be passed as arguments, so one copy can serve several filters:
+
+```
+freespace-ultra.sh [RELEASE_BYTES] [BUFFER_GIB] [ASSUME_GIB]
+```
+
+For a filter with `max_size` of 30GB that should keep 100 GiB free, set **Exec Args** to `{{.Size}} 100 30`.
+
+## Output
+
+Every run prints both numbers, so a skipped grab explains itself:
+
+```
+freespace: OK - quota 250 GiB free, array 10509 GiB free, needs 55 GiB (release 5 GiB plus 50 GiB buffer)
+freespace: BLOCK - quota 40 GiB free, array 10509 GiB free, needs 80 GiB (size unknown, assumed 30 GiB plus 50 GiB buffer)
+```
+
+## Notes
+
+The script fails closed. If your quota cannot be read, it skips the release rather than falling back to `df`, because on a slot the array figure is not your headroom and trusting it is the failure this script exists to prevent.
+
+It is POSIX `sh` and passes `shellcheck`.

--- a/scripts/freespace-ultra/freespace-ultra.sh
+++ b/scripts/freespace-ultra/freespace-ultra.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# freespace-ultra - autobrr External Filter script for Ultra.cc slots.
+#
+# Exit 0 if the release fits, 1 if it does not or the quota cannot be read.
+# Usage: freespace-ultra.sh [RELEASE_BYTES] [BUFFER_GIB] [ASSUME_GIB]
+
+set -u
+
+buffer_gib=50        # keep this much free on top of the release
+assume_gib=50        # assume this size when the announce carries none
+check_path="$HOME"   # any path on the filesystem you download to
+
+kib_per_gib=1048576
+bytes_per_kib=1024
+
+die() { echo "freespace: $1"; exit 1; }
+is_number() { case "$1" in ''|*[!0-9]*) return 1 ;; esac; }
+
+release_bytes="${1:-0}"
+[ $# -ge 2 ] && buffer_gib="$2"
+[ $# -ge 3 ] && assume_gib="$3"
+
+is_number "$buffer_gib" || die "BUFFER_GIB must be a whole number, got '$buffer_gib'"
+is_number "$assume_gib" || die "ASSUME_GIB must be a whole number, got '$assume_gib'"
+
+# Your quota, in 1 KiB blocks. A slot has exactly one quota row:
+#   Disk quotas for user user1 (uid 1000):
+#        Filesystem  blocks   quota   limit   grace   files   quota   limit
+#         /dev/sda1 9503171676  9765388288 9765388288           20081  0  0
+# Not `quota -s`: it prints human units that change scale, so a 1.5T limit reads
+# back as 15 once the letters are stripped. `blocks` gains a '*' when over soft.
+used_kib=""
+limit_kib=""
+while read -r fs blocks soft hard _rest; do
+    blocks=${blocks%\*}
+    is_number "$fs" && continue          # a wrapped row leads with a number
+    is_number "$blocks" || continue      # skips both header lines
+    used_kib=$blocks
+    limit_kib=$hard
+    [ "$limit_kib" = 0 ] && limit_kib=$soft
+    break
+done <<EOF
+$(quota -w 2>/dev/null)
+EOF
+
+# No quota is not a valid state on a slot, it is a fault. df alone would report
+# the shared array, which is terabytes, so grabbing on that would fill the disk.
+[ -n "$used_kib" ] || die "BLOCK - cannot read your quota, so nothing is safe to grab"
+is_number "$limit_kib" || die "BLOCK - quota limit is not a number, got '$limit_kib'"
+[ "$limit_kib" != 0 ] || die "BLOCK - no quota limit is set on this slot"
+
+quota_free_kib=$(( limit_kib - used_kib ))
+[ "$quota_free_kib" -lt 0 ] && quota_free_kib=0
+
+# The shared array can fill while your quota still has room, so take the smaller:
+#   Filesystem     1024-blocks       Used   Available Capacity Mounted on
+#   /dev/sda1      27328354232 16305874084 11019729288      60% /home1
+read -r _dev _blocks _used array_free_kib _rest <<EOF
+$(df -Pk "$check_path" 2>/dev/null | tail -n 1)
+EOF
+is_number "$array_free_kib" || die "cannot read df for $check_path"
+
+free_kib=$quota_free_kib
+[ "$array_free_kib" -lt "$free_kib" ] && free_kib=$array_free_kib
+
+# autobrr resolves a missing size only after external filters run, so {{.Size}}
+# arrives as 0 for any tracker that leaves size off the announce line. Reading
+# that as "needs nothing" would let any release through.
+if [ -z "$release_bytes" ] || [ "$release_bytes" = 0 ]; then
+    need_kib=$(( assume_gib * kib_per_gib ))
+    size_note="size unknown, assumed $assume_gib GiB"
+elif is_number "$release_bytes"; then
+    need_kib=$(( (release_bytes + bytes_per_kib - 1) / bytes_per_kib ))
+    size_note="release $(( need_kib / kib_per_gib )) GiB"
+else
+    die "RELEASE_BYTES must be a whole number, got '$release_bytes'. Use {{.Size}}."
+fi
+
+need_kib=$(( need_kib + buffer_gib * kib_per_gib ))
+
+report="quota $(( quota_free_kib / kib_per_gib )) GiB free, array $(( array_free_kib / kib_per_gib )) GiB free, needs $(( need_kib / kib_per_gib )) GiB ($size_note plus $buffer_gib GiB buffer)"
+
+if [ "$free_kib" -le "$need_kib" ]; then
+    echo "freespace: BLOCK - $report"
+    exit 1
+fi
+
+echo "freespace: OK - $report"
+exit 0


### PR DESCRIPTION
On Ultra.cc your home lives on a shared array and your plan is a filesystem quota. `df` shows the array rather than your quota, and so does qBittorrent's own free space number, so a slot with 250 GiB left can look like it has 10 TiB free and the check never fires.

This reads the quota instead and uses whichever is smaller. Filters with no size constraint are handled too, since `{{.Size}}` comes through as 0 on those and the script falls back to an assumed size.

Same idea as freespace-hbd, just for Ultra.cc. shellcheck clean, tested on two live slots.