### PR TITLE
fix(scripts): correct freespace-ultra size resolution docs

### DIFF
--- a/scripts/freespace-ultra/README.md
+++ b/scripts/freespace-ultra/README.md
@@ -28,19 +28,13 @@ Everything here is in GiB, matching your torrent client. The Ultra panel shows G
 
 ## Releases with no announced size
 
-Not every tracker puts a size on the announce line. autobrr only works the real size out *after* external filters have run:
+Not every tracker puts a size on the announce line. What happens then depends on whether your filter has a size constraint.
 
-```go
-func (f *Filter) checkSizeFilter(r *Release) bool {
-	if r.Size == 0 {
-		r.AdditionalSizeCheckRequired = true
-		return true
-	}
-```
+**Set a `Min Size` or `Max Size` on the filter.** autobrr then fetches the real size out of band, from the `.torrent` file or from the tracker API on RED, OPS, GGN and BTN. That happens in `CheckFilter` before external filters run, so `{{.Size}}` is already correct by the time this script executes and the check is exact. This is the recommended setup.
 
-So `{{.Size}}` arrives here as `0`, and a `max_size` on the filter does not change that. Reading `0` as "needs nothing" would let any release through, so the script assumes `ASSUME_GIB`.
+**With no size constraint at all**, `checkSizeFilter` is never reached, nothing is fetched, and `{{.Size}}` arrives as `0`. Reading `0` as "needs nothing" would let any release through, so the script falls back to `ASSUME_GIB`.
 
-Set `ASSUME_GIB` to your filter's `max_size`. That is the largest release the filter can accept, so the guess is never too big or too small.
+Set `ASSUME_GIB` to the largest release you would accept on that filter. It is only used in that fallback case.
 
 ## Configuration
 
@@ -49,7 +43,7 @@ Edit the values at the top of the script:
 | Variable | Meaning |
 | --- | --- |
 | `BUFFER_GIB` | Headroom to keep free on top of the release. Default 50. |
-| `ASSUME_GIB` | Size assumed when the announce carries no size. Set to your filter's `max_size`. Default 50. |
+| `ASSUME_GIB` | Fallback size, used only when the filter has no size constraint and the announce carries no size. Default 50. |
 | `CHECK_PATH` | Any path on the filesystem you download to. Defaults to `$HOME`. |
 
 `BUFFER_GIB` and `ASSUME_GIB` can also be passed as arguments, so one copy can serve several filters:
@@ -58,7 +52,7 @@ Edit the values at the top of the script:
 freespace-ultra.sh [RELEASE_BYTES] [BUFFER_GIB] [ASSUME_GIB]
 ```
 
-For a filter with `max_size` of 30GB that should keep 100 GiB free, set **Exec Args** to `{{.Size}} 100 30`.
+To keep 100 GiB free on a filter, set **Exec Args** to `{{.Size}} 100`.
 
 ## Output
 

--- a/scripts/freespace-ultra/freespace-ultra.sh
+++ b/scripts/freespace-ultra/freespace-ultra.sh
@@ -63,9 +63,9 @@ is_number "$array_free_kib" || die "cannot read df for $check_path"
 free_kib=$quota_free_kib
 [ "$array_free_kib" -lt "$free_kib" ] && free_kib=$array_free_kib
 
-# autobrr resolves a missing size only after external filters run, so {{.Size}}
-# arrives as 0 for any tracker that leaves size off the announce line. Reading
-# that as "needs nothing" would let any release through.
+# {{.Size}} is 0 only when the announce carries no size AND the filter sets no
+# Min/Max Size. With one set, autobrr fetches the real size before external
+# filters run. Reading 0 as "needs nothing" would let any release through.
 if [ -z "$release_bytes" ] || [ "$release_bytes" = 0 ]; then
     need_kib=$(( assume_gib * kib_per_gib ))
     size_note="size unknown, assumed $assume_gib GiB"


### PR DESCRIPTION
I got this wrong in #6. I wrote that autobrr resolves a missing size only after external filters run, and that setting a `max_size` does not change it.

Neither is true. `checkSizeFilter` only runs when Min or Max Size is set, and the size fetch happens before `RunExternalFilters`, so with a size constraint set `{{.Size}}` is already correct when the script runs.

The README now says to set one, and `ASSUME_GIB` is documented as what it is: the fallback for filters with no size constraint. Same fix to a code comment. No behavior change.

Thanks to the dev who caught it.