### PR TITLE
Use df with POSIX output format in freespace.sh scripts

### DIFF
--- a/scripts/freespace-docker/freespace.sh
+++ b/scripts/freespace-docker/freespace.sh
@@ -2,7 +2,7 @@
 set -e
 
 reqSpace=250000000 # 250GB
-SPACE=$(df "/torrents" | awk 'END{print $4}')
+SPACE=$(df -P "/torrents" | awk 'END{print $4}')
 if [ "$SPACE" -le $reqSpace ]
 then
   echo "not enough space"

--- a/scripts/freespace-generic/freespace.sh
+++ b/scripts/freespace-generic/freespace.sh
@@ -2,7 +2,7 @@
 set -e
 
 reqSpace=100000000 # 100GB
-SPACE=`df "$HOME/torrents" | awk 'END{print $4}'`
+SPACE=`df -P "$HOME/torrents" | awk 'END{print $4}'`
 if [[ $SPACE -le reqSpace ]]
 then
   #echo "not enough space"


### PR DESCRIPTION
This prevents errors when checking for free space on network mounted disks. For example with a nfs drive mounted at `/data/media` `df` will create a multi line output by default:

```bash
df /data/media
10.10.10.1:/mnt/usb-drives/data/media
		 5813121024 4991092736 528989184  90% /data/media
```

This messes up the value extraction via awk, resulting in the script not stopping downloads, instead it just outputs:

```bash
not sh: 90%: bad number
got space
free 90%
```

The -P option forces single line output, which fixes the issue